### PR TITLE
Namespace Miss

### DIFF
--- a/src/AlohaKit.Animations/Triggers/AnimateCornerRadius.cs
+++ b/src/AlohaKit.Animations/Triggers/AnimateCornerRadius.cs
@@ -1,4 +1,4 @@
-﻿namespace AlohaKit.Animations.Triggers
+﻿namespace AlohaKit.Animations
 {
     using System;
     using System.Threading.Tasks;

--- a/src/AlohaKit.Animations/Triggers/AnimateInt.cs
+++ b/src/AlohaKit.Animations/Triggers/AnimateInt.cs
@@ -1,4 +1,4 @@
-﻿namespace AlohaKit.Animations.Triggers
+﻿namespace AlohaKit.Animations
 {
     using System;
     using System.Threading.Tasks;

--- a/src/AlohaKit.Animations/Triggers/AnimateThickness.cs
+++ b/src/AlohaKit.Animations/Triggers/AnimateThickness.cs
@@ -1,4 +1,4 @@
-﻿namespace AlohaKit.Animations.Triggers
+﻿namespace AlohaKit.Animations
 {
     using System;
     using System.Threading.Tasks;


### PR DESCRIPTION
In some of the classes in the Triggers subfolder, use the 
Some namespaces are different

For this reason, the following features are less consistent, so we've unified the namespaces.

AlohaKit.Animations.Triggers -> AlohaKit.Animations

- AnimateCornerRadius
- AnimateInt
- AnimateThickness